### PR TITLE
Remove promotional and credit links from footer

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -603,16 +603,6 @@
 					understand and accept the
 					<a href="/policy/data" class="underline">Monierate data policy</a>.
 				</p>
-				<p class="text-sm">
-					Built and maintained by <a
-						href="https://twitter.com/jeremyikwuje"
-						class="text-gray-800 dark:text-gray-300">@jeremyikwuje ⚡</a
-					>
-					and
-					<a href="https://twitter.com/onionsman" class="text-gray-800 dark:text-gray-300"
-						>@onionsman</a
-					>
-				</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This PR removes the following links and text from the footer for clarity and UI cleanup:

- "Pay your importers"
- "Sell crypto on Koyn"
- "Compare Currency Exchange Rates"
- "Send money to Europe"
- "Send USD on Cedar Money"
- "Convert USDT on Remitano"
- "Convert USDT on Yellowcard"
- "Convert USD on Changera"
- "Convert USD on Wirepay"
- "Convert USD on Coinprofile"
- "Convert USDT on Bitmama"
- "Built and maintained by @jeremyikwuje ⚡ and @onionsman"

All changes are under `footer` cleanup.
